### PR TITLE
Change Texture UVs to use 32 bit floats

### DIFF
--- a/draft-jennings-dispatch-game-state-over-rtp.md
+++ b/draft-jennings-dispatch-game-state-over-rtp.md
@@ -161,8 +161,8 @@ Normal vector for a point.
 
 ```
 TextureUV1 ::=
- VarUInt /* u */
- VarUInt /* v */
+ Float32 /* u */
+ Float32 /* v */
 ```
 
 Location in texture map for a point.
@@ -756,8 +756,8 @@ Norm1 ::=
  Float16 /* z */
 
 TextureUV1 ::=
- VarUInt /* u */
- VarUInt /* v */
+ Float32 /* u */
+ Float32 /* v */
 
 Rot1 ::=
  Float16 /* i */

--- a/game.ebnf
+++ b/game.ebnf
@@ -112,8 +112,8 @@ Norm1 ::=
  Float16 /* z */
 
 TextureUV1 ::=
- VarUInt /* u */
- VarUInt /* v */
+ Float32 /* u */
+ Float32 /* v */
 
 Rot1 ::=
  Float16 /* i */


### PR DESCRIPTION
UVs range from 0-1. When textures are
larger than 2048 texels in a dimension,
16 bit precision is no longer enough,
hence the 32bit choice.